### PR TITLE
Add fields from entry to email in JSON format

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -2,6 +2,7 @@ package logrus_mail
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/mail"
@@ -148,6 +149,8 @@ func (hook *MailHook) Levels() []logrus.Level {
 func createMessage(entry *logrus.Entry, appname string) *bytes.Buffer {
 	body := entry.Time.Format(format) + " - " + entry.Message
 	subject := appname + " - " + entry.Level.String()
-	message := bytes.NewBufferString(fmt.Sprintf("Subject: %s\r\n\r\n%s", subject, body))
+	fields, _ := json.MarshalIndent(entry.Data, "", "\t")
+	contents := fmt.Sprintf("Subject: %s\r\n\r\n%s\r\n\r\n%s", subject, body, fields)
+	message := bytes.NewBufferString(contents)
 	return message
 }


### PR DESCRIPTION
I noticed that the entry's fields were not being printed in the email. I don't know if everyone else's use case matches mine, but I think it is worthwhile to have the data from the Entry be printed in the email.

Let me know what you think, and if anything else should be changed to make this a viable PR.
