### PR TITLE
Fix how sender and recipient are set for mail hook without auth

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -53,8 +53,12 @@ func NewMailHook(appname string, host string, port int, from string, to string) 
 	}
 
 	// Set the sender and recipient.
-	c.Mail(sender.String())
-	c.Rcpt(recipient.String())
+	if err := c.Mail(sender.Address); err != nil {
+		return nil, err
+	}
+	if err := c.Rcpt(recipient.Address); err != nil {
+		return nil, err
+	}
 
 	return &MailHook{
 		AppName: appname,


### PR DESCRIPTION
Address.String returns an address in angle brackets, while c.Mail and c.Rcpt accepts address in plain format.
Sorry, no test with it (no obvious way to do that without making a mock smtp server?).  
